### PR TITLE
Add IOException for `retriever.release()` because build error in ANDR…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0+2
+
+- Add IOException for `retriever.release()` because build error in ANDROID SDK 33.
+
 ## 1.0.0+1
 
 - Update `build:gradle` version.

--- a/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
+++ b/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
@@ -3,6 +3,7 @@ package com.alexmercerind.flutter_media_metadata;
 import java.util.HashMap;
 import java.lang.Runnable;
 import java9.util.concurrent.CompletableFuture;
+import java.io.IOException;
 
 import android.os.Build;
 import android.os.Handler;
@@ -39,7 +40,11 @@ public class FlutterMediaMetadataPlugin implements FlutterPlugin, MethodCallHand
           final HashMap<String, Object> response = new HashMap<String, Object>();
           response.put("metadata", retriever.getMetadata());
           response.put("albumArt", retriever.getAlbumArt());
-          retriever.release();
+          try {
+            retriever.release();
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
           new Handler(Looper.getMainLooper())
               .post(new Runnable() {
                 @Override

--- a/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
+++ b/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
+import android.util.Log;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;

--- a/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
+++ b/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
@@ -43,7 +43,7 @@ public class FlutterMediaMetadataPlugin implements FlutterPlugin, MethodCallHand
           try {
             retriever.release();
           } catch (IOException e) {
-            e.printStackTrace();
+            Log.e("FlutterMediaMetadata", "Error releasing MetadataRetriever", e);
           }
           new Handler(Looper.getMainLooper())
               .post(new Runnable() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_media_metadata
 description: A Flutter plugin to read metadata of media files.
-version: 1.0.0+1
+version: 1.0.0+2
 homepage: https://github.com/alexmercerind/flutter_media_metadata
 repository: https://github.com/alexmercerind/flutter_media_metadata
 documentation: https://github.com/alexmercerind/flutter_media_metadata/blob/master/README.md


### PR DESCRIPTION
Add IOException for `retriever.release()` because build error in ANDROID SDK 33.